### PR TITLE
Fix code scanning alert no. 2: Database query built from user-controlled sources

### DIFF
--- a/pages/api/v1/events/register/index.js
+++ b/pages/api/v1/events/register/index.js
@@ -43,7 +43,7 @@ export default async function handler(req, res) {
                 participantSchema
             );
 
-            const existingParticipant = await Participant.findOne({ email });
+            const existingParticipant = await Participant.findOne({ email: { $eq: email } });
 
             if (existingParticipant) {
                 return res.status(400).json({


### PR DESCRIPTION
Fixes [https://github.com/SRM-IST-KTR/githubsrmv2/security/code-scanning/2](https://github.com/SRM-IST-KTR/githubsrmv2/security/code-scanning/2)

To fix the problem, we need to ensure that the user input is interpreted as a literal value and not as a query object. This can be achieved by using the `$eq` operator in the MongoDB query. This approach ensures that the `email` field is treated as a literal value, preventing any potential NoSQL injection attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
