### PR TITLE
Fix code scanning alert no. 1: Database query built from user-controlled sources

### DIFF
--- a/pages/api/v1/certificates/index.js
+++ b/pages/api/v1/certificates/index.js
@@ -9,10 +9,10 @@ export default async function handler(req, res) {
     if (req.method === "POST") {
         const { email, event, type } = req.body;
 
-        if (!email || !event || !type) {
+        if (!email || !event || !type || typeof email !== "string") {
             return res
                 .status(400)
-                .json({ success: false, error: "All fields are required." });
+                .json({ success: false, error: "All fields are required and email must be a string." });
         }
 
         try {
@@ -59,7 +59,7 @@ export default async function handler(req, res) {
             });
 
             const User = db.model(eventData.collection[type], userSchema);
-            const userData = await User.findOne({ email });
+            const userData = await User.findOne({ email: { $eq: email } });
 
             if (!userData || !userData.checkin) {
                 return res.status(404).json({


### PR DESCRIPTION
Fixes [https://github.com/SRM-IST-KTR/githubsrmv2/security/code-scanning/1](https://github.com/SRM-IST-KTR/githubsrmv2/security/code-scanning/1)

Fixes #99 

To fix the problem, we need to ensure that the `email` value is treated as a literal value and not as a query object. This can be achieved by using MongoDB's `$eq` operator, which ensures that the value is interpreted as a literal string. Additionally, we should validate that the `email` is a string before using it in the query.
