### PR TITLE
Refactor EmailDialogue component to use email instead of name; update API handler to validate email field

### DIFF
--- a/components/Events/EmailDialogue/EmailDialogue.jsx
+++ b/components/Events/EmailDialogue/EmailDialogue.jsx
@@ -4,18 +4,18 @@ import { toast, ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 
 const EmailDialogBox = ({ CertiOBJ, title, handelCloseModel }) => {
-    // const [formData, setFormData] = useState({
-    //     email: "",
-    //     type: "",
-    //     event: title
-    // });
-
-    //only for ossome hacks 2
     const [formData, setFormData] = useState({
-        name: "",
+        email: "",
         type: "",
         event: title
     });
+
+    //only for ossome hacks 2
+    // const [formData, setFormData] = useState({
+    //     name: "",
+    //     type: "",
+    //     event: title
+    // });
     const [emailError, setEmailError] = useState("");
     const [certificate, setCertificate] = useState(null);
     const [isLoading, setIsLoading] = useState(false);
@@ -29,7 +29,7 @@ const EmailDialogBox = ({ CertiOBJ, title, handelCloseModel }) => {
     };
 
     const handleEmailChange = (event) => {
-        setFormData({ ...formData, name: event.target.value });
+        setFormData({ ...formData, email: event.target.value });
     };
 
     const handleRoleChange = (event) => {
@@ -38,10 +38,10 @@ const EmailDialogBox = ({ CertiOBJ, title, handelCloseModel }) => {
 
     const handleGetCertificate = async (e) => {
         e.preventDefault();
-        // if (!validateEmail(formData.email)) {
-        //     setEmailError("Please enter a valid SRMIST email address.");
-        //     return;
-        // }
+        if (!validateEmail(formData.email)) {
+            setEmailError("Please enter a valid SRMIST email address.");
+            return;
+        }
         setEmailError("");
         setIsButtonDisabled(true);
         try {
@@ -117,15 +117,15 @@ const EmailDialogBox = ({ CertiOBJ, title, handelCloseModel }) => {
                     <div className="rounded-md">
                         <div>
                             <label htmlFor="email" className="text-gray-800">
-                                Name
+                                Email
                             </label>
                             <input
-                                placeholder="Enter Name"
+                                placeholder="Enter Email"
                                 className="appearance-none relative block w-full px-3 py-3 border border-gray-100 bg-gray-100 rounded-md focus:outline-none focus:ring-bright_green focus:border-bright_green focus:z-10 text-black mb-8 mt-2 font-semibold"
                                 required
-                                type="text"
-                                name="text"
-                                value={formData.name}
+                                type="email"
+                                name="email"
+                                value={formData.email}
                                 id="email"
                                 onChange={handleEmailChange}
                             />

--- a/pages/api/v1/certificates/index.js
+++ b/pages/api/v1/certificates/index.js
@@ -7,23 +7,23 @@ DBInstance();
 
 export default async function handler(req, res) {
     if (req.method === "POST") {
-        // const { email, event, type } = req.body;
+        const { email, event, type } = req.body;
 
         //only for ossome hacks 2
-        const { name, event, type } = req.body;
+        // const { name, event, type } = req.body;
 
-        // if (!email || !event || !type) {
-        //     return res
-        //         .status(400)
-        //         .json({ success: false, error: "All fields are required." });
-        // }
-
-        //only for ossome hacks 2
-        if (!name || !event || !type) {
+        if (!email || !event || !type) {
             return res
                 .status(400)
                 .json({ success: false, error: "All fields are required." });
         }
+
+        //only for ossome hacks 2
+        // if (!name || !event || !type) {
+        //     return res
+        //         .status(400)
+        //         .json({ success: false, error: "All fields are required." });
+        // }
 
         try {
             const eventData = await Event.findOne({ slug: event });
@@ -69,28 +69,28 @@ export default async function handler(req, res) {
             });
 
             const User = db.model(eventData.collection[type], userSchema);
-            // const userData = await User.findOne({ email });
+            const userData = await User.findOne({ email });
 
             //only for ossome hacks 2
-            const userData = await User.findOne({
-                name: { $regex: new RegExp(`^${name}$`, 'i') }
-            });
-
-            // if (!userData || !userData.checkin) {
-            //     return res.status(404).json({
-            //         success: false,
-            //         error: `No certificate found for email: ${email}`
-            //     });
-            // }
-
-            //only for ossome hacks 2
+            // const userData = await User.findOne({
+            //     name: { $regex: new RegExp(`^${name}$`, 'i') }
+            // });
 
             if (!userData) {
                 return res.status(404).json({
                     success: false,
-                    error: `No certificate found for name: ${name}`
+                    error: `No certificate found for email: ${email}`
                 });
             }
+
+            //only for ossome hacks 2
+
+            // if (!userData) {
+            //     return res.status(404).json({
+            //         success: false,
+            //         error: `No certificate found for name: ${name}`
+            //     });
+            // }
             // console.log("User data:", userData);
 
             const color =


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Certificate retrieval system now uses email as the primary identifier instead of name, improving overall lookup reliability
  * Certificate request interface updated to require email address instead of name
  * Email validation is now actively enforced during certificate submission
  * Error messages now reference email for clearer feedback when certificates cannot be found

<!-- end of auto-generated comment: release notes by coderabbit.ai -->